### PR TITLE
Fixed an issue where `where clause is ambiguous` could occur

### DIFF
--- a/core/strings.go
+++ b/core/strings.go
@@ -13,6 +13,8 @@ func toSnake(str string) string {
 				i++
 			}
 			p = i
+		} else if !(c >= 'a' && c <= 'z') {
+			p = i
 		}
 	}
 	return string(runes)

--- a/core/strings_test.go
+++ b/core/strings_test.go
@@ -8,4 +8,6 @@ func TestToSnake(t *testing.T) {
 	assertEqual(t, toSnake("TestID"), "test_id")
 	assertEqual(t, toSnake("ImageURL"), "image_url")
 	assertEqual(t, toSnake("AbCdEf"), "ab_cd_ef")
+	assertEqual(t, toSnake("models.ID"), "models.id")
+	assertEqual(t, toSnake("`models`.`ID`"), "`models`.`id`")
 }


### PR DESCRIPTION
When using join query, an error may occur.