### PR TITLE
Fixed a bug related to concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ pageboy
 ==========
 [![CircleCI](https://circleci.com/gh/soranoba/pageboy.svg?style=svg&circle-token=977b6c270d30867fe12a0e65d34f8adbb3d7d7f2)](https://circleci.com/gh/soranoba/pageboy)
 [![Go Report Card](https://goreportcard.com/badge/github.com/soranoba/pageboy)](https://goreportcard.com/report/github.com/soranoba/pageboy)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/soranoba/pageboy/v2)](https://pkg.go.dev/github.com/soranoba/pageboy/v2)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/soranoba/pageboy/v3)](https://pkg.go.dev/github.com/soranoba/pageboy/v3)
 
 `pageboy` is a pagination library with [GORM v2](https://github.com/go-gorm/gorm).
 
@@ -21,7 +21,7 @@ pageboy
 To install it, run:
 
 ```bash
-go get -u github.com/soranoba/pageboy/v2
+go get -u github.com/soranoba/pageboy/v3
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ CREATE INDEX created_at_id ON users (created_at DESC, id DESC);
 #### Usage in Codes
 
 ```go
+db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
+// Please execute it only once immediately after opening DB.
+pageboy.RegisterCallbacks(db)
+```
+
+```go
 type UsersRequest struct {
 	pageboy.Cursor
 }
@@ -100,6 +106,12 @@ It includes a page which is 1-Based number, and per_page.
 - `https://example.com/users?page=1&per_page=10`
 
 #### Usage in Codes
+
+```go
+db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
+// Please execute it only once immediately after opening DB.
+pageboy.RegisterCallbacks(db)
+```
 
 ```go
 type UsersRequest struct {

--- a/cursor.go
+++ b/cursor.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	pbc "github.com/soranoba/pageboy/v2/core"
+	pbc "github.com/soranoba/pageboy/v3/core"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )

--- a/cursor.go
+++ b/cursor.go
@@ -143,8 +143,6 @@ func (cursor *Cursor) Order(orders ...string) *Cursor {
 // Scope returns a GORM scope.
 func (cursor *Cursor) Scope() func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
-		registerCursorCallbacks(db)
-
 		cursor.baseOrder = pbc.ASC
 		if len(cursor.orders) > 0 {
 			cursor.baseOrder = cursor.orders[0]

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -10,6 +10,8 @@ import (
 
 func ExampleCursor() {
 	db := openDB()
+	// Please execute it only once immediately after opening DB.
+	RegisterCallbacks(db)
 
 	type User struct {
 		gorm.Model

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/soranoba/pageboy/v2
+module github.com/soranoba/pageboy/v3
 
 go 1.15
 

--- a/pageboy.go
+++ b/pageboy.go
@@ -6,3 +6,13 @@
 // Source code: https://github.com/soranoba/pageboy
 //
 package pageboy
+
+import "gorm.io/gorm"
+
+// RegisterCallbacks register the Callback used by pageboy in gorm.DB.
+// This function MUST execute only once immediately after opening the DB. (https://pkg.go.dev/gorm.io/gorm#Open)
+// DO NOT execute every time you create new Session (https://pkg.go.dev/gorm.io/gorm#DB.Session).
+func RegisterCallbacks(db *gorm.DB) {
+	registerCursorCallbacks(db)
+	registerPagerCallbacks(db)
+}

--- a/pager.go
+++ b/pager.go
@@ -56,7 +56,6 @@ func (pager *Pager) Validate() error {
 // Scope returns a GORM scope.
 func (pager *Pager) Scope() func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
-		registerPagerCallbacks(db)
 		db = db.InstanceSet("pageboy:pager", pager)
 		return db.Offset((pager.Page - 1) * pager.PerPage).Limit(pager.PerPage)
 	}

--- a/pager_test.go
+++ b/pager_test.go
@@ -9,6 +9,8 @@ import (
 
 func ExamplePager() {
 	db := openDB()
+	// Please execute it only once immediately after opening DB.
+	RegisterCallbacks(db)
 
 	type User struct {
 		gorm.Model

--- a/tests/cursor_test.go
+++ b/tests/cursor_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soranoba/pageboy/v2"
-	pbc "github.com/soranoba/pageboy/v2/core"
+	"github.com/soranoba/pageboy/v3"
+	pbc "github.com/soranoba/pageboy/v3/core"
 	"gorm.io/gorm"
 )
 

--- a/tests/cursor_test.go
+++ b/tests/cursor_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/url"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1331,6 +1332,32 @@ func TestCursor_where_clause_is_ambiguous(t *testing.T) {
 	assertEqual(t, *cursor.BuildNextPagingUrls(url), pageboy.CursorPagingUrls{
 		Next: "",
 	})
+}
+
+func TestCursor_concurrency(t *testing.T) {
+	db := openDB()
+	assertNoError(t, db.Migrator().DropTable(&cursorModel{}))
+	assertNoError(t, db.AutoMigrate(&cursorModel{}))
+
+	assertNoError(t, db.Create(&cursorModel{}).Error)
+	assertNoError(t, db.Create(&cursorModel{}).Error)
+	assertNoError(t, db.Create(&cursorModel{}).Error)
+	assertNoError(t, db.Create(&cursorModel{}).Error)
+	assertNoError(t, db.Create(&cursorModel{}).Error)
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			cursor := &pageboy.Cursor{
+				Limit: 10,
+			}
+			var models []cursorModel
+			assertNoError(t, db.Session(&gorm.Session{}).Scopes(cursor.Paginate("CreatedAt", "ID").Order(ASC, ASC).Scope()).Find(&models).Error)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func ExampleCursor() {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,7 +3,7 @@ module github.com/soranoba/pageboy/tests
 go 1.15
 
 require (
-	github.com/soranoba/pageboy/v2 v2.0.0
+	github.com/soranoba/pageboy/v3 v3.0.0
 	gorm.io/driver/mysql v1.0.2
 	gorm.io/driver/postgres v1.0.2
 	gorm.io/driver/sqlite v1.1.3
@@ -11,4 +11,4 @@ require (
 	gorm.io/gorm v1.21.2
 )
 
-replace github.com/soranoba/pageboy/v2 => ../
+replace github.com/soranoba/pageboy/v3 => ../

--- a/tests/pageboy_test.go
+++ b/tests/pageboy_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/soranoba/pageboy/v2"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -68,6 +69,7 @@ func openDB() *gorm.DB {
 		)
 	}
 
+	pageboy.RegisterCallbacks(db)
 	if err != nil {
 		panic(fmt.Sprintf("failed to open a database: %+v", err))
 	}

--- a/tests/pageboy_test.go
+++ b/tests/pageboy_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/soranoba/pageboy/v2"
+	"github.com/soranoba/pageboy/v3"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"

--- a/tests/pager_test.go
+++ b/tests/pager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soranoba/pageboy/v2"
+	"github.com/soranoba/pageboy/v3"
 	"gorm.io/gorm"
 )
 


### PR DESCRIPTION
There was a bug that panic occurred when it was executed in parallel more than a certain amount.
It was due to the inability to have exclusive control of Callback.

This PR avoids this by pre-configuring Callbacks.
As a result, setup is required, so I will consider it as a destructive change and change a major version after the PR merged.